### PR TITLE
Docker Desktop (Windows and Mac) dont have the docker0 network interf…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,26 @@
 version: '3.1'
 services:
   zookeeper:
-    image: quay.io/debezium/zookeeper:1.9
+    image: 'bitnami/zookeeper:latest'
     ports:
-      - 2181:2181
-      - 2888:2888
-      - 3888:3888
-    networks:
-      debezium_static_network:
-        ipv4_address: 10.5.0.5
-  kafka:
-    image: quay.io/debezium/kafka:1.9
+      - '2181:2181'
     environment:
-      - ZOOKEEPER_CONNECT=10.5.0.5:2181
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'bitnami/kafka:latest'
     ports:
-      - 9092:9092
+      - '9092:9092'
+      - '9093:9093'
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
     depends_on:
-      - zookeeper
-    networks:
-      debezium_static_network:
-        ipv4_address: 10.5.0.6    
+      - zookeeper 
   mysql:
     image: quay.io/debezium/example-mysql:1.9
     environment:
@@ -27,34 +28,20 @@ services:
       - MYSQL_USER=mysqluser
       - MYSQL_PASSWORD=mysqlpw
     ports:
-      - 3306:3306
+      - '3306:3306'
     depends_on:
       - kafka
       - zookeeper
-    networks:
-      debezium_static_network:
-        ipv4_address: 10.5.0.7
   connect:
     image: quay.io/debezium/connect:1.9
     environment:
       - CONFIG_STORAGE_TOPIC=my_connect_configs 
       - OFFSET_STORAGE_TOPIC=my_connect_offsets 
       - STATUS_STORAGE_TOPIC=my_connect_statuses
-      - BOOTSTRAP_SERVERS=10.5.0.6:9092
+      - BOOTSTRAP_SERVERS=kafka:9092
     ports:
-      - 8083:8083 
+      - '8083:8083'
     depends_on:
       - zookeeper
       - kafka
       - mysql
-    networks:
-      debezium_static_network:
-        ipv4_address: 10.5.0.8
-
-networks:
-  debezium_static_network:
-    driver: bridge
-    ipam:
-     config:
-       - subnet: 10.5.0.0/16
-         gateway: 10.5.0.1

--- a/inventory-cdc/src/main/resources/application.properties
+++ b/inventory-cdc/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.kafka.consumer.value-deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+spring.kafka.bootstrap-servers=localhost:9093

--- a/inventory-cdc/src/test/java/com/example/inventorycdc/product/IntegrationTests.java
+++ b/inventory-cdc/src/test/java/com/example/inventorycdc/product/IntegrationTests.java
@@ -31,7 +31,7 @@ public class IntegrationTests {
     @Container
     public static DockerComposeContainer environment =
             new DockerComposeContainer(new File("src/test/resources/docker-compose.yml"))
-                    .withExposedService("kafka", 9092, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30L)))
+                    .withExposedService("kafka", 9093, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30L)))
                     .withExposedService("mysql", 3306, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30L)))
                     .withExposedService("connect", 8083, Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30L)));
 
@@ -44,7 +44,7 @@ public class IntegrationTests {
     }
 
     private static String getKafkaURL() {
-        return "localhost:" + environment.getServicePort("kafka", 9092);
+        return "localhost:" + environment.getServicePort("kafka", 9093);
     }
 
     @Test

--- a/inventory-cdc/src/test/resources/docker-compose.yml
+++ b/inventory-cdc/src/test/resources/docker-compose.yml
@@ -1,15 +1,23 @@
 version: '3.1'
 services:
   zookeeper:
-    image: quay.io/debezium/zookeeper:1.9
-  kafka:
-    image: quay.io/debezium/kafka:1.9
+    image: 'bitnami/zookeeper:latest'
+    ports:
+      - '2181:2181'
     environment:
-      - ZOOKEEPER_CONNECT=zookeeper:2181
-    depends_on:
-      - zookeeper
-    links:
-      - "zookeeper:zookeeper"
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: 'bitnami/kafka:latest'
+    ports:
+      - '9093:9093'
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9093
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
   mysql:
     image: quay.io/debezium/example-mysql:1.9
     environment:


### PR DESCRIPTION
Docker Desktop (Windows and Mac) don't have the `docker0` network interface, which causes issues when the app tries to connect to Kafka running on Docker (docker desktop for windows and mac only, it works fine for Docker Linux). 

I'm moving to a more flexible docker image with settings that I can customise to allow multiple hosts in the advertised settings.